### PR TITLE
[ppamppam] 6주차 작업

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+  <head>
+    <title>6주차</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <div class="query-selector--test-area">
+      <div class="test">
+        <div class="test1">
+          <div class="test11"></div>
+        </div>
+        <div class="test2">
+          <div class="test21"></div>
+          <div class="test22"></div>
+        </div>
+      </div>
+    </div>
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,0 +1,6 @@
+import App from "./src/app.js";
+import _$ from "./src/util/MyQuerySelector.js";
+
+const app = new App({
+  $target: _$("#app").querySelector("#app")
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "fe-w6-frontend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "public/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "type": "module"
+}

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -1,0 +1,8 @@
+class App {
+  constructor({ $target }) {
+    this.$target = $target;
+    $target.appendChild(document.createElement("section"));
+  }
+}
+
+export default App;

--- a/frontend/src/util/MyDocument.js
+++ b/frontend/src/util/MyDocument.js
@@ -1,0 +1,74 @@
+class $document {
+  constructor(){};
+}
+
+// static method
+$document.querySelector = function(query, $parent = undefined) { 
+  const finder = $document.finderCreate(query);
+  return $document.find(query, finder, $parent);
+}
+
+$document.find = function(query, finder = null, $parent = document.body, stack = []) {
+  // DFS 리프노드 종료 조건
+  if ($parent === "") {
+    return false;
+  }
+  
+  // 개발자가 잘못해서 자기 자신을 찾는 경우
+  if (finder.attribute === $parent[finder.findby] ) {
+    console.log($parent)
+    return $parent;
+  }
+  
+  
+  for (const child of [...$parent.children]) {
+    if (finder.attribute !== child[finder.findby]) {
+      stack.push(child);
+      const result = $document.find(query, finder, child, stack);
+      if (result) {
+        return result;
+      }
+      stack.pop();
+    } else {
+      return child;
+    }
+  }
+}
+
+$document.finderCreate = function(query) {
+  const classPattern = /[.]/g;
+  const idPattern = /[#]/g;
+  const finder = {};
+  
+  if (query.match(classPattern)) {
+    query.split(classPattern).map((element, idx) => {
+      if (idx === 0) { finder.tag = element }
+      else if (idx === 1) { finder.attribute = element }
+    });
+    finder.findby = "className";
+    return finder;
+  } 
+  else if (query.match(idPattern)) {
+    query.split(idPattern).map((element, idx) => {
+      if (idx === 0) { finder.tag = element }
+      else if (idx === 1) { finder.attribute = element }
+    });
+    finder.findby = "id";
+    return finder;
+  }
+}
+
+// MyQuerySelector와 함께 하용하는 경우
+$document.startFromSelector = function(query) {
+  const $parent = $document.querySelector(query);
+  
+  // 체이닝의 형태처럼 작동하도록 클로저 활용
+  const state = {
+    querySelector: (query) => {
+      return $document.querySelector(query, $parent);
+    }
+  }
+  return state;
+}
+
+export default $document;

--- a/frontend/src/util/MyQuerySelector.js
+++ b/frontend/src/util/MyQuerySelector.js
@@ -1,0 +1,28 @@
+// document.myquerySelector => 네이티브 타입을 수정하지 말자. 안티패턴
+// $(document).myquerySelector => jquery의 모습을 해보자.
+
+/*
+  description:
+  1) _$(startElementString : queryString)
+    => return (customized-state with querySelector function)
+  
+  // HIGHLY RECOMMEND
+  2) _$(startElementString : queryString).querySelector(query: queryString)
+    => return HTMLDOMElement;
+  
+  3) _$().querySelector(query: queryString) : It's OK but start from rootnode which is document.body
+
+  4) $document.querySelector(query: queryString): It also OK but find from rootnode which is document.body
+*/
+
+import $document from "./MyDocument.js"
+
+const _$ = (startElement = document.body) => {
+  if (typeof startElement === "string") {
+    return $document.startFromSelector(startElement);
+  } else {
+    return $document;
+  }
+}
+
+export default _$;


### PR DESCRIPTION
## 구현 내용
- 나만의 쿼리셀렉터 함수 만들기
  - ```$document```클래스를 활용한 static function 구현 작업 
    - DFS 방식의 className, id 쿼리셀렉트
    - querySelector의 시작지점을 자유롭게 설정하기 위한 커스텀 함수 구현 (startFromSelector())
  - 쿼리 셀렉트 시작Element 설정을 위한 ```_$()``` 함수 구현
    - ```$document.startFromSelector```함수와 함께 사용됩니다.

---
## 사용방법
  1) _$(startElementString : queryString)
    => return (customized-state with querySelector function)
  

  2) _$(startElementString : queryString).querySelector(query: queryString)    ```// HIGHLY RECOMMENDED```
    => return HTMLDOMElement;
  
3) _$().querySelector(query: queryString) : It's OK but start from rootnode which is document.body
4) $document.querySelector(query: queryString): It also OK but find from rootnode which is document.body