### PR TITLE
[Beemo] 캔들차트 완성 및 검색 자동완성 기능 추가

### DIFF
--- a/stock/public/scss/main.scss
+++ b/stock/public/scss/main.scss
@@ -68,6 +68,20 @@ header {
   border-top: 5px solid rgb(200, 200, 200);
   &__term {
     display: flex;
+    padding-bottom: 10px;
+    border-bottom: 1px solid #000;
+    > li {
+      > label {
+        padding: 5px 10px;
+        margin: 0 10px 0 0;
+        border-radius: 10px;
+        cursor: pointer;
+      }
+      > input[type="radio"]:checked + label {
+        background: #445f9a;
+        color: #fff;
+      }
+    }
   }
   &__chart {
     height: 500px;

--- a/stock/public/scss/main.scss
+++ b/stock/public/scss/main.scss
@@ -119,6 +119,13 @@ header {
   }
 }
 
+.suggestion {
+  font-size: 16px;
+  background: #fff;
+  border: 1px solid gray;
+  width: 224px;
+}
+
 .red {
   color: red;
 }

--- a/stock/public/scss/util.scss
+++ b/stock/public/scss/util.scss
@@ -1,5 +1,6 @@
 ul {
   padding: 0;
+  margin: 0;
 }
 li {
   list-style: none;

--- a/stock/public/src/CandleChart/CandleChartView.js
+++ b/stock/public/src/CandleChart/CandleChartView.js
@@ -1,36 +1,53 @@
-import fetch from 'cross-fetch';
+import _ from '../util.js'
 import * as echarts from 'echarts';
-import { splitData } from './candleChartUtil.js';
-import { basicOption, makeXAxis, makeSeries, dispatchActionOption } from './candleChartOption.js';
+import { splitData, xhrRequest } from './candleChartUtil.js';
+import { basicOption, makeXAxis, makeSeries } from './candleChartOption.js';
 
 class CandleChartView {
-  constructor({ url, $boxChart }) {
+  constructor({ url, $receiveInput, $receiveButton, $boxChartTerm, $boxChart, today }) {
     this.url = url;
+    this.$receiveInput = $receiveInput;
+    this.$receiveButton = $receiveButton;
+    this.$boxChartTerm = $boxChartTerm;
     this.$boxChart = $boxChart;
+    this.today = today;
     this.init();
   }
 
   init() {
-    this.render();
+    this.initEvent();
   }
 
-  render() {
-    // const url = `${this.url}?requestType=1&timeframe=day&startTime=20210103&endTime=20210208&symbol=035720`
-    const ROOT_PATH = 'https://echarts.apache.org/examples';
+  initEvent() {
+    _.on(this.$receiveButton, 'click', this.radioBoxOriginalStateHandler.bind(this));
+    _.on(this.$receiveButton, 'click', this.renderChart.bind(this, this.$receiveInput.value, 'day'));
+    _.on(this.$boxChartTerm, 'click', this.changeRadioButtonHandler.bind(this));
+  }
+
+  changeRadioButtonHandler({ target }) {
+    if (target.tagName !== 'LABEL') return;
+    target.previousElementSibling.checked = 'checked';
+    this.renderChart(this.$receiveInput.value, target.id);
+  }
+
+  radioBoxOriginalStateHandler() {
+    _.$('#day', this.$boxChartTerm).checked = 'checked';
+  }
+
+  renderChart(tickerCode, term) {
+    const url = `${this.url}?requestType=1&timeframe=${term}&startTime=20140103&endTime=${this.today}&symbol=${tickerCode}`;
     const myChart = echarts.init(this.$boxChart);
     let option;
 
-    fetch(ROOT_PATH + '/data/asset/data/stock-DJI.json')
-      .then(data => data.json())
-      .then((rawData) => {
-        const data = splitData(rawData);
-        option = { ...basicOption, xAxis: makeXAxis(data), series: makeSeries(data) };
-        myChart.setOption(option, true);
-        myChart.dispatchAction(dispatchActionOption);
-      });
+    xhrRequest(url, (rawData) => {
+      const data = splitData(rawData);
+      option = { ...basicOption, xAxis: makeXAxis(data), series: makeSeries(data) };
+      myChart.setOption(option, true);
+    });
 
     option && myChart.setOption(option);
   }
+
 }
 
 export default CandleChartView;

--- a/stock/public/src/CandleChart/CandleChartView.js
+++ b/stock/public/src/CandleChart/CandleChartView.js
@@ -2,12 +2,12 @@ import _ from '../util.js'
 import * as echarts from 'echarts';
 import { splitData, xhrRequest } from './candleChartUtil.js';
 import { basicOption, makeXAxis, makeSeries } from './candleChartOption.js';
+import { attrMutationObserver } from '../serviceUtil.js';
 
 class CandleChartView {
-  constructor({ url, $receiveInput, $receiveButton, $boxChartTerm, $boxChart, today }) {
+  constructor({ url, $stockInput, $boxChartTerm, $boxChart, today }) {
     this.url = url;
-    this.$receiveInput = $receiveInput;
-    this.$receiveButton = $receiveButton;
+    this.$stockInput = $stockInput
     this.$boxChartTerm = $boxChartTerm;
     this.$boxChart = $boxChart;
     this.today = today;
@@ -15,19 +15,21 @@ class CandleChartView {
   }
 
   init() {
+    attrMutationObserver(this.$stockInput, (mutations) => {
+      this.radioBoxOriginalStateHandler();
+      this.renderChart(mutations[0].target.dataset.stockCode.trim(), 'day');
+    })
     this.initEvent();
   }
 
   initEvent() {
-    _.on(this.$receiveButton, 'click', this.radioBoxOriginalStateHandler.bind(this));
-    _.on(this.$receiveButton, 'click', this.renderChart.bind(this, this.$receiveInput.value, 'day'));
     _.on(this.$boxChartTerm, 'click', this.changeRadioButtonHandler.bind(this));
   }
 
   changeRadioButtonHandler({ target }) {
     if (target.tagName !== 'LABEL') return;
     target.previousElementSibling.checked = 'checked';
-    this.renderChart(this.$receiveInput.value, target.id);
+    this.renderChart(this.$stockInput.dataset.stockCode.trim(), target.id);
   }
 
   radioBoxOriginalStateHandler() {

--- a/stock/public/src/CandleChart/candleChartOption.js
+++ b/stock/public/src/CandleChart/candleChartOption.js
@@ -3,6 +3,10 @@ import { calculateMA } from './candleChartUtil.js';
 const color = {
   up: '#EE3739',
   down: '#0A7DF2',
+  day5: '#00C50D',
+  day20: '#FF333A',
+  day60: '#F48416',
+  day120: '#BB69FF'
 }
 
 const basicOption = {
@@ -23,7 +27,7 @@ const basicOption = {
     textStyle: {
       color: '#000'
     },
-    position: function (pos, params, el, elRect, size) {
+    position(pos, params, el, elRect, size) {
       const obj = { top: 10 };
       obj[['left', 'right'][+(pos[0] < size.viewSize[0] / 2)]] = 30;
       return obj;
@@ -98,7 +102,7 @@ const basicOption = {
     {
       type: 'inside',
       xAxisIndex: [0, 1],
-      start: 98,
+      start: 97,
       end: 100
     },
     {
@@ -106,7 +110,7 @@ const basicOption = {
       xAxisIndex: [0, 1],
       type: 'slider',
       top: '85%',
-      start: 98,
+      start: 97,
       end: 100
     }
   ],
@@ -157,46 +161,62 @@ function makeSeries(data) {
         color0: color.down,
         borderColor: null,
         borderColor0: null
+      },
+      tooltip: {
+        formatter: function (param) {
+          param = param[0];
+          return [
+            'Date: ' + param.name + '<hr size=1 style="margin: 3px 0">',
+            'Open: ' + param.data[0] + '<br/>',
+            'Close: ' + param.data[1] + '<br/>',
+            'Lowest: ' + param.data[2] + '<br/>',
+            'Highest: ' + param.data[3] + '<br/>'
+          ].join('');
+        }
       }
     },
     {
       name: '5일',
       type: 'line',
+      symbol: 'none',
       data: calculateMA(5, data),
-      color: '#00C50D',
+      color: color.day5,
       smooth: true,
       lineStyle: {
-        opacity: 0.5
+        opacity: 0.4
       }
     },
     {
       name: '20일',
       type: 'line',
+      symbol: 'none',
       data: calculateMA(20, data),
-      color: '#FF333A',
+      color: color.day20,
       smooth: true,
       lineStyle: {
-        opacity: 0.5
+        opacity: 0.4
       }
     },
     {
       name: '60일',
       type: 'line',
+      symbol: 'none',
       data: calculateMA(60, data),
-      color: '#F48416',
+      color: color.day60,
       smooth: true,
       lineStyle: {
-        opacity: 0.5
+        opacity: 0.4
       }
     },
     {
       name: '120일',
       type: 'line',
+      symbol: 'none',
       data: calculateMA(120, data),
-      color: '#BB69FF',
+      color: color.day120,
       smooth: true,
       lineStyle: {
-        opacity: 0.5
+        opacity: 0.4
       }
     },
     {
@@ -209,14 +229,4 @@ function makeSeries(data) {
   ]
 }
 
-const dispatchActionOption = {
-  type: 'brush',
-  areas: [
-    {
-      brushType: 'lineX',
-      coordRange: ['2016-06-02', '2016-06-20'],
-      xAxisIndex: 0
-    }
-  ]
-}
-export { basicOption, makeXAxis, makeSeries, dispatchActionOption };
+export { basicOption, makeXAxis, makeSeries };

--- a/stock/public/src/CandleChart/candleChartUtil.js
+++ b/stock/public/src/CandleChart/candleChartUtil.js
@@ -1,12 +1,16 @@
 function splitData(rawData) {
+  rawData.splice(0, 1);
   const categoryData = [];
   const values = [];
   const volumes = [];
+  let prevVolume = 0;
   for (let i = 0; i < rawData.length; i++) {
     categoryData.push(rawData[i].splice(0, 1)[0]);
-    values.push(rawData[i]);
-    volumes.push([i, rawData[i][4], rawData[i][0] > rawData[i][1] ? 1 : -1]);
+    values.push([rawData[i][0], rawData[i][3], rawData[i][2], rawData[i][1], rawData[i][4]]);
+    volumes.push([i, rawData[i][4], rawData[i][4] > prevVolume ? -1 : 1]);
+    prevVolume = rawData[i][4];
   }
+
   return {
     categoryData: categoryData,
     values: values,
@@ -30,4 +34,12 @@ function calculateMA(dayCount, data) {
   return result;
 }
 
-export { splitData, calculateMA };
+
+function xhrRequest(url, callback) {
+  const xhr = new XMLHttpRequest();
+  xhr.onreadystatechange = () => { if (xhr.readyState === 4) callback(eval(xhr.response)) };
+  xhr.open('GET', url, true);
+  xhr.send('');
+}
+
+export { splitData, calculateMA, xhrRequest };

--- a/stock/public/src/CandleChart/serviceUtil.js
+++ b/stock/public/src/CandleChart/serviceUtil.js
@@ -1,3 +1,0 @@
-const delay = (data, ms) => new Promise(resolve => setTimeout(() => resolve(data), ms));
-
-export { delay };

--- a/stock/public/src/CandleChart/serviceUtil.js
+++ b/stock/public/src/CandleChart/serviceUtil.js
@@ -1,0 +1,3 @@
+const delay = (data, ms) => new Promise(resolve => setTimeout(() => resolve(data), ms));
+
+export { delay };

--- a/stock/public/src/DailyPriceView.js
+++ b/stock/public/src/DailyPriceView.js
@@ -2,12 +2,13 @@ import _ from './util.js';
 import { getResponseJsonUrl } from './serviceUtil.js';
 
 class DailyPriceView {
-  constructor({ url, $receiveInput, $receiveButton, $tableBody }) {
+  constructor({ url, $receiveInput, $receiveButton, $tableBody, today }) {
     this.url = url;
     this.$receiveInput = $receiveInput;
     this.$receiveButton = $receiveButton;
     this.$tableBody = $tableBody;
     this.tickerCode = '';
+    this.today = today;
     this.bizDate = '';
     this.scrollTimer = null;
     this.initEvent();
@@ -20,7 +21,7 @@ class DailyPriceView {
 
   async enterCodeAndClickHandler() {
     this.tickerCode = this.$receiveInput.value;
-    this.bizDate = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+    this.bizDate = this.today;
     const dailyPriceArray = await getResponseJsonUrl(`${this.url}&code=${this.tickerCode}&bizdate=${this.bizDate}`);
     this.updateLastDate(dailyPriceArray);
     this.$tableBody.innerHTML = this.makeTemplate(dailyPriceArray);

--- a/stock/public/src/SearchBarView.js
+++ b/stock/public/src/SearchBarView.js
@@ -1,0 +1,73 @@
+import { delay } from "./serviceUtil.js";
+import _ from "./util.js";
+
+class SearchBarView {
+  constructor({ url, $receiveInput, $searchBar }) {
+    this.url = url;
+    this.$receiveInput = $receiveInput;
+    this.$searchBar = $searchBar;
+    this.$suggestion;
+    this.suggestionData = [];
+    this.typingTimer = null;
+    this.init();
+  }
+
+  init() {
+    window['searchBarJsonp'] = this.responseJsonp.bind(this);
+    this.initEvent();
+
+    this.$suggestion = this.createElement();
+    this.$searchBar.appendChild(this.$suggestion);
+  }
+
+  initEvent() {
+    _.on(this.$receiveInput, 'input', this.inputSuggestionHandler.bind(this));
+  }
+
+  inputSuggestionHandler({ target: { value } }) {
+    if (this.typingTimer) clearTimeout(this.typingTimer);
+    this.typingTimer = setTimeout(async function () {
+      await delay(this.requestJsonp(this.url, value), 300);
+      this.$suggestion.innerHTML = this.makeTemplate(this.suggestionData, value);
+    }.bind(this), 300);
+  }
+
+  requestJsonp(url, word, callbackName = 'searchBarJsonp') {
+    const script = document.createElement('script');
+    script.src = `${url}&q=${word}&_callback=${callbackName}`;
+    document.body.append(script);
+  }
+
+  responseJsonp({ items }) {
+    console.log(items[0])
+    const stocksArray = items[0].filter(infoArray => /[0-9]/g.test(infoArray[0]) && infoArray[0][0].length === 6);
+    this.suggestionData = stocksArray.map(infoArray => {
+      const [code, name] = [...infoArray[0], ...infoArray[1]];
+      return { code, name };
+    });
+  }
+
+  createElement() {
+    return _.genEl('DIV', {
+      classNames: ['suggestion'],
+      // attributes: { hidden: true },
+    });
+  }
+
+  makeTemplate(dataArray, word) {
+    const stockDataTemplate = `${dataArray.map(item => {
+      return `<li>
+                <span class="ticker_code">${item.code}</span>
+                <span>${item.name.replace(word, `<span class="red">${word}</span>`)}</span>
+              </li>`;
+    }).join('')}`;
+
+    const template = `<ul>
+                       ${stockDataTemplate}
+                      </ul>`;
+
+    return template;
+  }
+}
+
+export default SearchBarView;

--- a/stock/public/src/SearchBarView.js
+++ b/stock/public/src/SearchBarView.js
@@ -39,7 +39,6 @@ class SearchBarView {
   }
 
   responseJsonp({ items }) {
-    console.log(items[0])
     const stocksArray = items[0].filter(infoArray => /[0-9]/g.test(infoArray[0]) && infoArray[0][0].length === 6);
     this.suggestionData = stocksArray.map(infoArray => {
       const [code, name] = [...infoArray[0], ...infoArray[1]];
@@ -50,15 +49,18 @@ class SearchBarView {
   createElement() {
     return _.genEl('DIV', {
       classNames: ['suggestion'],
-      // attributes: { hidden: true },
     });
   }
 
   makeTemplate(dataArray, word) {
     const stockDataTemplate = `${dataArray.map(item => {
       return `<li>
-                <span class="ticker_code">${item.code}</span>
-                <span>${item.name.replace(word, `<span class="red">${word}</span>`)}</span>
+                <span class="ticker_code">
+                 ${item.code.replace(word, `<span class="red">${word}</span>`)}
+                </span>
+                <span>
+                 ${item.name.replace(word, `<span class="red">${word}</span>`)}
+                </span>
               </li>`;
     }).join('')}`;
 

--- a/stock/public/src/TickerCodeView.js
+++ b/stock/public/src/TickerCodeView.js
@@ -1,0 +1,26 @@
+import _ from './util.js';
+
+class TickerCodeView {
+  constructor({ $receiveInput, $receiveButton, $stockInput }) {
+    this.$receiveInput = $receiveInput;
+    this.$receiveButton = $receiveButton;
+    this.$stockInput = $stockInput;
+    this.initEvent();
+  }
+
+  initEvent() {
+    _.on(this.$receiveButton, 'click', this.registerStockCodeClickHandler.bind(this));
+    _.on(this.$receiveInput, 'keydown', this.registerStockCodeEnterHandler.bind(this));
+  }
+
+  registerStockCodeClickHandler() {
+    this.$stockInput.dataset.stockCode = _.$All('.ticker_code')[0].innerText.trim();
+  }
+
+  registerStockCodeEnterHandler({ keyCode }) {
+    if (keyCode === 13) this.$receiveButton.click();
+  }
+
+}
+
+export default TickerCodeView;

--- a/stock/public/src/TitleView.js
+++ b/stock/public/src/TitleView.js
@@ -1,5 +1,4 @@
 import _ from './util.js';
-import { delay } from './serviceUtil.js';
 
 class TitleView {
   constructor({ url, $receiveInput, $receiveButton, $tickerCode, $name, $price, $gap }) {
@@ -14,7 +13,7 @@ class TitleView {
   }
 
   init() {
-    window['responseJsonp'] = this.responseJsonp.bind(this);
+    window['titleJsonp'] = this.responseJsonp.bind(this);
     this.initEvent();
   }
 
@@ -26,7 +25,7 @@ class TitleView {
     this.requestJsonp(this.url, this.$receiveInput.value.trim());
   }
 
-  requestJsonp(url, word, callbackName = 'responseJsonp') {
+  requestJsonp(url, word, callbackName = 'titleJsonp') {
     const script = document.createElement('script');
     script.src = `${url}?_callback=${callbackName}&query=SERVICE_ITEM%3A${word}`;
     document.body.append(script);

--- a/stock/public/src/TitleView.js
+++ b/stock/public/src/TitleView.js
@@ -1,10 +1,10 @@
 import _ from './util.js';
+import { attrMutationObserver } from './serviceUtil.js';
 
 class TitleView {
-  constructor({ url, $receiveInput, $receiveButton, $tickerCode, $name, $price, $gap }) {
+  constructor({ url, $stockInput, $tickerCode, $name, $price, $gap }) {
     this.url = url;
-    this.$receiveInput = $receiveInput;
-    this.$receiveButton = $receiveButton;
+    this.$stockInput = $stockInput;
     this.$tickerCode = $tickerCode;
     this.$name = $name;
     this.$price = $price;
@@ -14,15 +14,7 @@ class TitleView {
 
   init() {
     window['titleJsonp'] = this.responseJsonp.bind(this);
-    this.initEvent();
-  }
-
-  initEvent() {
-    _.on(this.$receiveButton, 'click', this.enterCodeAndClickHandler.bind(this));
-  }
-
-  enterCodeAndClickHandler() {
-    this.requestJsonp(this.url, this.$receiveInput.value.trim());
+    attrMutationObserver(this.$stockInput, this.mutationHandler.bind(this));
   }
 
   requestJsonp(url, word, callbackName = 'titleJsonp') {
@@ -46,6 +38,11 @@ class TitleView {
     const gapTemplate = `<span class="${color}"><span>${fluctuationRate}${Math.abs(comparison)}</span></span> 
                          <span class="${color}"><span>${percent}</span><span>%</span></span>`;
     this.$gap.innerHTML = gapTemplate;
+  }
+
+  mutationHandler(mutations) {
+    const stockCode = mutations[0].target.dataset.stockCode.trim();
+    this.requestJsonp(this.url, stockCode);
   }
 }
 

--- a/stock/public/src/main.js
+++ b/stock/public/src/main.js
@@ -2,50 +2,53 @@ import _ from './util.js';
 import TitleView from './TitleView.js';
 import DailyPriceView from './DailyPriceView.js';
 import CandleChartView from './CandleChart/CandleChartView.js';
+import TickerCodeView from './TickerCodeView.js';
+import SearchBarView from './SearchBarView.js';
 
 const load = () => {
+
+  const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
   const receive = {
     $receiveInput: _.$('.receive_input'),
-    $receiveButton: _.$('.receive_button')
+    $receiveButton: _.$('.receive_button'),
+    $stockInput: _.$('._stock_input')
   }
+  const tickerCodeView = new TickerCodeView(receive);
+
   const title = {
     url: 'https://polling.finance.naver.com/api/realtime',
-    $receiveInput: receive.$receiveInput,
-    $receiveButton: receive.$receiveButton,
+    $stockInput: receive.$stockInput,
     $tickerCode: _.$('.title__info--code'),
     $name: _.$('.title__info--name'),
     $price: _.$('.title__info--price'),
     $gap: _.$('.title__info--gap')
   }
-
   const titleView = new TitleView(title);
 
   const daily = {
     url: 'https://m.stock.naver.com/api/item/getTrendList.nhn?size=10',
-    $receiveInput: receive.$receiveInput,
-    $receiveButton: receive.$receiveButton,
-    $tableBody: _.$('.table__body')
+    $stockInput: receive.$stockInput,
+    $tableBody: _.$('.table__body'),
+    today: today
   }
-
   const dailyPriceView = new DailyPriceView(daily);
-
-  // var url = 'https://fchart.stock.naver.com/siseJson.nhn?symbol=035720&requestType=1&startTime=20210103&endTime=20210208&timeframe=day'; //A local page
-  // function aa(url, callback) {
-  //   const xhr = new XMLHttpRequest();
-  //   xhr.onreadystatechange = () => { if (xhr.readyState === 4) callback(eval(xhr.response)) };
-  //   xhr.open('GET', url, true);
-  //   xhr.send('');
-  // }
-
-  // const c = (data) => { console.log(data) }
-  // aa(url, c)
 
   const candle = {
     url: 'https://fchart.stock.naver.com/siseJson.nhn',
+    $stockInput: receive.$stockInput,
+    $boxChartTerm: _.$('.box_chart__term'),
     $boxChart: _.$('.box_chart__chart'),
+    today: today
   }
-
   const candleChartView = new CandleChartView(candle);
+
+  const search = {
+    url: 'https://ac.finance.naver.com/ac?q_enc=euc-kr&st=111&frm=stock&r_format=json&r_enc=euc-kr&r_unicode=0&t_koreng=1&r_lt=111',
+    $receiveInput: receive.$receiveInput,
+    $searchBar: _.$('.search_bar')
+  }
+  const searchBarView = new SearchBarView(search);
+
 }
 
 window.addEventListener('DOMContentLoaded', load);

--- a/stock/public/src/serviceUtil.js
+++ b/stock/public/src/serviceUtil.js
@@ -1,4 +1,8 @@
 const delay = (data, ms) => new Promise(resolve => setTimeout(() => resolve(data), ms));
 const getResponseJsonUrl = async (url) => (await fetch(url)).json();
-
-export { delay, getResponseJsonUrl };
+const attrMutationObserver = ($element, callback) => {
+  const observer = new MutationObserver(callback);
+  const config = { attributes: true };
+  observer.observe($element, config);
+}
+export { delay, getResponseJsonUrl, attrMutationObserver };

--- a/stock/public/src/util.js
+++ b/stock/public/src/util.js
@@ -2,6 +2,19 @@ const _ = {
   $: (selector, base = document) => base.querySelector(selector),
   $All: (selector, base = document) => base.querySelectorAll(selector),
   on: (selector, eventName, callback, option) => selector.addEventListener(eventName, callback, option),
+  genEl(tagName, { classNames, template, attributes } = {}) {
+    const $el = document.createElement(tagName);
+    if (classNames) $el.classList.add(...classNames);
+    if (template) $el.innerHTML = template;
+    if (attributes) Object.entries(attributes).forEach(([k, v]) => $el.setAttribute(k, v));
+    return $el;
+  },
+  show($target) {
+    $target.hidden = false;
+  },
+  hide($target) {
+    $target.hidden = true;
+  }
 }
 
 export default _;

--- a/stock/views/main.html
+++ b/stock/views/main.html
@@ -11,19 +11,14 @@
 </head>
 
 <body>
-  https://m.stock.naver.com/sise/siseIndex.nhn?code=KOSPI
-  <br>
-  035720- 카카오종목코드
-  <br>
-  035420- 네이버종목코드
   <div class="entirety">
     <header>
       <div>N 증권</div>
       <div> &nbsp;&nbsp;국내증시</div>
-      <div>
-        <input class="receive_input" type="text" placeholder="종목코드 입력" value="035720">
+      <div class="search_bar">
+        <input class="receive_input" type="text" placeholder="종목코드 입력">
         <button class="receive_button">
-          이동
+          검색
         </button>
       </div>
       <div>MY</div>

--- a/stock/views/main.html
+++ b/stock/views/main.html
@@ -17,6 +17,7 @@
       <div> &nbsp;&nbsp;국내증시</div>
       <div class="search_bar">
         <input class="receive_input" type="text" placeholder="종목코드 입력">
+        <input class="_stock_input" type="text" data-stock-code='' hidden>
         <button class="receive_button">
           검색
         </button>

--- a/stock/views/main.html
+++ b/stock/views/main.html
@@ -55,9 +55,9 @@
     <section class="box_chart">
       <div>
         <ul class="box_chart__term">
-          <li><button>일봉</button></li>
-          <li><button>주봉</button></li>
-          <li><button>월봉</button></li>
+          <li><input type="radio" name="rod_term" id="day" checked hidden><label id="day">일봉</label></li>
+          <li><input type="radio" name="rod_term" id="week" hidden><label id="week">주봉</label></li>
+          <li><input type="radio" name="rod_term" id="month" hidden><label id="month">월봉</label></li>
         </ul>
       </div>
       <div class="box_chart__chart"> </div>


### PR DESCRIPTION
## feature List

+ ### 타이틀부분에 검색한 종목(종목이름, 가격, 퍼센트) 그려주기
   - [x] 종목, 가격, 퍼센트 그려주기
   - [x] 날짜 그려주기 

+ ### 검색 바 자동완성기능
   - [x] 자동완성
   - [x] 컬러로 하이라이트
   - [ ] 키보드 방향키로 하나씩 이동

+ ### 차트그리기 2개
   - [x] echart로 day, week, month (일봉, 주봉, 월봉, 거래량) 차트 만들기
      - [x] 데이터 가져오기
      - [x] 그려주기 (옵션 변경)
   - [ ]  하루 실시간 단위 차트 만들기
      - [ ] 데이터 가져오기
      - [ ] 그려주기

+ ###  무한스크롤 
   - [x] 일별시세 데이터 가져오기
   - [x] 무한 스크롤로 뿌려주기
   - [ ] Intersection Observer 사용해보기


<br>

### 주저리

+ 옵저버 패턴은 왜이리 어려울까요.. 도전하다가 실패하고 다른방법인 MutationObserver를 사용해서 data-set을 변경하는 방식으로 수정을 하긴했는데  다음에는 옵저버 패턴을 도전해보고 싶습니다 
+ TodoList를 옵저버 패턴으로 사용하는 예제를 찾아봤는데 그것마저 너무 복잡하고 어렵게 느껴지더라구요.. 

<br>

+ 실시간 차트는  데이터를 찾아봐도 찾기 어려운것 같습니다.. 주식 거래소 API를 가져왔어야했나봐요..
+ 일단은 Inersection Observer부터 처리해보겠습니다